### PR TITLE
最終挙動確認【Basic認証の有効化】

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  # before_action :basic_auth
+  before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
@@ -10,9 +10,9 @@ class ApplicationController < ActionController::Base
                                              :first_name_kana, :birthday])
   end
 
-  # def basic_auth
-  # authenticate_or_request_with_http_basic do |username, password|
-  # username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]  # 環境変数を読み込む記述に変更
-  # end
-  # end
+  def basic_auth
+  authenticate_or_request_with_http_basic do |username, password|
+  username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]  # 環境変数を読み込む記述に変更
+  end
+  end
 end


### PR DESCRIPTION
#### Why
・Basic認証の導入
#### What
・Basic認証の記述がコメントアウトされていたため、コメントアウトを外して有効にした。
